### PR TITLE
Add CI check for demo example

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,31 @@
+name: build-demo
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-demo:
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_DATE_EPOCH: 1755796661
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install TeX Live
+        run: sudo apt-get update && sudo apt-get install -y texlive-full latexmk
+
+      - name: Build package
+        run: |
+          latex notation.ins
+          l3build doc
+
+      - name: Compile demo
+        run: |
+          cp examples/demo.pdf /tmp/demo.pdf
+          latexmk -pdf -interaction=nonstopmode examples/demo.tex
+
+      - name: Verify example PDF
+        run: cmp /tmp/demo.pdf examples/demo.pdf

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -23,9 +23,7 @@ jobs:
           l3build doc
 
       - name: Compile demo
-        run: |
-          cp examples/demo.pdf /tmp/demo.pdf
-          latexmk -pdf -interaction=nonstopmode examples/demo.tex
+        run: latexmk -pdf -interaction=nonstopmode -outdir=/tmp examples/demo.tex
 
       - name: Verify example PDF
         run: cmp /tmp/demo.pdf examples/demo.pdf


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build package
- compile examples/demo.tex and verify generated PDF matches repository
- trigger workflow on push and pull request to `main`

## Testing
- `latex notation.ins` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a757666c28832c820c22e32f434886